### PR TITLE
Razorgenerator manifest file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,6 @@
 # RazorEngine
 
+This is my first change!
 Documentation also available on http://antaris.github.io/RazorEngine.
 
 ## Build status

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,5 @@
 # RazorEngine
 
-This is my first change!
 Documentation also available on http://antaris.github.io/RazorEngine.
 
 ## Build status

--- a/src/source/RazorEngine.Generator/source.extension.vsixmanifest
+++ b/src/source/RazorEngine.Generator/source.extension.vsixmanifest
@@ -1,21 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="RazorEngine.Generator..2ffb8c5b-953e-4e7a-b676-625494b7b8b2" Version="1.2" Language="en-US" Publisher="Vasili Puchko" />
-    <DisplayName>RazorEngine.Generator</DisplayName>
+<Vsix xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2010">
+  <Identifier Id="RazorEngine.Generator..2ffb8c5b-953e-4e7a-b676-625494b7b8b2">
+    <Name>RazorEngine.Generator</Name>
+    <Author>Vasili Puchko</Author>
+    <Version>1.2</Version>
     <Description xml:space="preserve">Generator tool to generate C# code for Razor views using RazorEngine library</Description>
-    <License>LICENSE.txt</License>
-    <Tags>RazorEngine Generator</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,13.0)" />
-    <InstallationTarget Version="[11.0,13.0)" Id="Microsoft.VisualStudio.Premium" />
-    <InstallationTarget Version="[11.0,13.0)" Id="Microsoft.VisualStudio.Ultimate" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
-</PackageManifest>
+    <Locale>1033</Locale>
+    <InstalledByMsi>false</InstalledByMsi>
+    <SupportedProducts>
+      <VisualStudio Version="10.0">
+        <Edition>Ultimate</Edition>
+        <Edition>Premium</Edition>
+        <Edition>Pro</Edition>
+      </VisualStudio>
+      <VisualStudio Version="11.0">
+        <Edition>Ultimate</Edition>
+        <Edition>Premium</Edition>
+        <Edition>Pro</Edition>
+      </VisualStudio>
+      <VisualStudio Version="12.0">
+        <Edition>Ultimate</Edition>
+        <Edition>Premium</Edition>
+        <Edition>Pro</Edition>
+      </VisualStudio>
+      <VisualStudio Version="14.0">
+        <Edition>Ultimate</Edition>
+        <Edition>Premium</Edition>
+        <Edition>Pro</Edition>
+      </VisualStudio>    
+	</SupportedProducts>
+    <SupportedFrameworkRuntimeEdition MinVersion="4.0" MaxVersion="4.0" />
+  </Identifier>
+  <References />
+  <Content>
+    <VsPackage>|%CurrentProject%;PkgdefProjectOutputGroup|</VsPackage>
+  </Content>
+</Vsix>


### PR DESCRIPTION
This change in manifest file, makes the extension compatible with VS2010 as well.
Please note that VS2012 and above cannot display the information in manifest editor but still can compile it.
So, for any further updates on the manifest file, it should be modified manually in a text editor.